### PR TITLE
Create Supabase-ready FastAPI architecture in app1

### DIFF
--- a/app1/README.md
+++ b/app1/README.md
@@ -1,0 +1,59 @@
+# ADHD Productivity App 1 Architecture
+
+This directory hosts a ground-up rebuild of the ADHD productivity backend that is designed
+explicitly for Vercel hosting with Supabase providing persistence. It reuses the extensive
+Pydantic models from the original codebase while reorganising the application layers into a
+cleaner and more deployment-friendly structure.
+
+## Key Goals
+
+- **Serverless Ready** – The ASGI application can be imported directly by Vercel using
+  `app1.vercel:app`.
+- **Supabase Native** – Persistence is handled through the official Supabase Python client
+  with repositories that map the existing schemas to Supabase tables.
+- **Schema Reuse** – Existing Pydantic schemas are leveraged to ensure data validation
+  remains consistent with the previous implementation.
+- **Modular** – Clear boundaries across `core`, `infrastructure`, `domain`, `services`, and
+  `api` layers allow future features (e.g., ML powered insights) to plug in cleanly.
+
+## Layout
+
+```text
+app1/
+  api/               # FastAPI routers and dependencies
+  core/              # Configuration, logging, and exception helpers
+  domain/            # Data access repositories bound to Supabase
+  infrastructure/    # Third-party integration helpers (Supabase client factory)
+  services/          # High-level application use cases
+  main.py            # Application factory and FastAPI instance
+  vercel.py          # Entry point for Vercel deployments
+```
+
+## Environment Variables
+
+The new stack expects the following Supabase and Vercel variables to be configured:
+
+- `SUPABASE_URL`
+- `SUPABASE_SERVICE_ROLE_KEY` (preferred for server operations) or `SUPABASE_ANON_KEY`
+- `SUPABASE_USERS_TABLE` (optional override, defaults to `users`)
+- `SUPABASE_TASKS_TABLE` (optional override, defaults to `tasks`)
+- `VERCEL_PROJECT` (optional metadata)
+- `VERCEL_REGION` (optional metadata)
+
+Configure these variables in your local `.env` file for development and in Vercel's project
+settings for production deployments.
+
+## Running Locally
+
+```bash
+uvicorn app1.main:app --reload
+```
+
+This will launch the FastAPI application under the `/api` prefix as defined in
+`Settings.api_prefix`.
+
+## Deployment
+
+Create a `vercel.json` file at the repository root or project configuration pointing to the
+`app1/vercel.py` module. Vercel will automatically detect the `app` symbol exported from that
+module and serve the FastAPI application.

--- a/app1/__init__.py
+++ b/app1/__init__.py
@@ -1,0 +1,1 @@
+"""Package initialisation for the rebuilt application."""

--- a/app1/api/__init__.py
+++ b/app1/api/__init__.py
@@ -1,0 +1,18 @@
+"""API router assembly for the new application."""
+
+from fastapi import APIRouter
+
+from app1.api.routes import health, tasks, users
+
+
+def create_api_router() -> APIRouter:
+    """Compose the FastAPI router tree for the application."""
+
+    router = APIRouter()
+    router.include_router(health.router)
+    router.include_router(users.router)
+    router.include_router(tasks.router)
+    return router
+
+
+__all__ = ["create_api_router"]

--- a/app1/api/dependencies.py
+++ b/app1/api/dependencies.py
@@ -1,0 +1,25 @@
+"""Shared FastAPI dependencies for the new application stack."""
+
+from collections.abc import Generator
+
+from fastapi import Depends
+from supabase import Client
+
+from app1.core.config import Settings, get_settings
+from app1.infrastructure.supabase_client import get_supabase_client
+
+
+def get_app_settings() -> Settings:
+    """Return application settings instance."""
+
+    return get_settings()
+
+
+def supabase_client(settings: Settings = Depends(get_app_settings)) -> Generator[Client, None, None]:
+    """Yield a Supabase client configured from environment variables."""
+
+    client = get_supabase_client(settings)
+    yield client
+
+
+__all__ = ["get_app_settings", "supabase_client"]

--- a/app1/api/routes/__init__.py
+++ b/app1/api/routes/__init__.py
@@ -1,0 +1,1 @@
+"""Package initialisation for the rebuilt application."""

--- a/app1/api/routes/health.py
+++ b/app1/api/routes/health.py
@@ -1,0 +1,26 @@
+"""Health and metadata endpoints."""
+
+from fastapi import APIRouter, Depends
+
+from app1.api.dependencies import get_app_settings
+from app1.core.config import Settings
+
+router = APIRouter(tags=["health"], include_in_schema=False)
+
+
+@router.get("/health", summary="Service health check")
+def health(settings: Settings = Depends(get_app_settings)) -> dict[str, str]:
+    return {"status": "ok", "environment": settings.environment}
+
+
+@router.get("/info", summary="Application metadata")
+def info(settings: Settings = Depends(get_app_settings)) -> dict[str, str | None]:
+    return {
+        "project": settings.project_name,
+        "environment": settings.environment,
+        "vercel_project": settings.vercel_project,
+        "vercel_region": settings.vercel_region,
+    }
+
+
+__all__ = ["router"]

--- a/app1/api/routes/tasks.py
+++ b/app1/api/routes/tasks.py
@@ -1,0 +1,57 @@
+"""Task management endpoints for the Supabase powered stack."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, status
+from supabase import Client
+
+from app.schemas.task_schema import TaskCreate, TaskResponse, TaskUpdate
+from app1.api.dependencies import get_app_settings, supabase_client
+from app1.core.config import Settings
+from app1.domain.tasks.repository import SupabaseTaskRepository
+from app1.services.tasks import TaskService
+
+router = APIRouter(prefix="/tasks", tags=["tasks"])
+
+
+def get_task_service(
+    client: Client = Depends(supabase_client),
+    settings: Settings = Depends(get_app_settings),
+) -> TaskService:
+    repository = SupabaseTaskRepository(client, settings.supabase_tasks_table)
+    return TaskService(repository)
+
+
+@router.post("/", response_model=TaskResponse, status_code=status.HTTP_201_CREATED)
+def create_task(payload: TaskCreate, service: TaskService = Depends(get_task_service)) -> TaskResponse:
+    return service.create_task(payload)
+
+
+@router.get("/user/{user_id}", response_model=list[TaskResponse])
+def list_tasks(user_id: UUID, service: TaskService = Depends(get_task_service)) -> list[TaskResponse]:
+    return service.list_tasks(user_id)
+
+
+@router.get("/{task_id}", response_model=TaskResponse)
+def get_task(task_id: UUID, service: TaskService = Depends(get_task_service)) -> TaskResponse:
+    return service.get_task(task_id)
+
+
+@router.patch("/{task_id}", response_model=TaskResponse)
+def update_task(
+    task_id: UUID,
+    payload: TaskUpdate,
+    service: TaskService = Depends(get_task_service),
+) -> TaskResponse:
+    return service.update_task(task_id, payload)
+
+
+@router.delete("/{task_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_task(task_id: UUID, service: TaskService = Depends(get_task_service)) -> None:
+    service.delete_task(task_id)
+    return None
+
+
+__all__ = ["router"]

--- a/app1/api/routes/users.py
+++ b/app1/api/routes/users.py
@@ -1,0 +1,57 @@
+"""User related HTTP routes."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, status
+from supabase import Client
+
+from app.schemas.user_schema import UserCreateSchema, UserResponseSchema, UserUpdateSchema
+from app1.api.dependencies import get_app_settings, supabase_client
+from app1.core.config import Settings
+from app1.domain.users.repository import SupabaseUserRepository
+from app1.services.users import UserService
+
+router = APIRouter(prefix="/users", tags=["users"])
+
+
+def get_user_service(
+    client: Client = Depends(supabase_client),
+    settings: Settings = Depends(get_app_settings),
+) -> UserService:
+    repository = SupabaseUserRepository(client, settings.supabase_users_table)
+    return UserService(repository)
+
+
+@router.post("/", response_model=UserResponseSchema, status_code=status.HTTP_201_CREATED)
+def create_user(payload: UserCreateSchema, service: UserService = Depends(get_user_service)) -> UserResponseSchema:
+    return service.register_user(payload)
+
+
+@router.get("/", response_model=list[UserResponseSchema])
+def list_users(service: UserService = Depends(get_user_service)) -> list[UserResponseSchema]:
+    return service.list_users()
+
+
+@router.get("/{user_id}", response_model=UserResponseSchema)
+def get_user(user_id: UUID, service: UserService = Depends(get_user_service)) -> UserResponseSchema:
+    return service.get_user(user_id)
+
+
+@router.patch("/{user_id}", response_model=UserResponseSchema)
+def update_user(
+    user_id: UUID,
+    payload: UserUpdateSchema,
+    service: UserService = Depends(get_user_service),
+) -> UserResponseSchema:
+    return service.update_user(user_id, payload)
+
+
+@router.delete("/{user_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_user(user_id: UUID, service: UserService = Depends(get_user_service)) -> None:
+    service.delete_user(user_id)
+    return None
+
+
+__all__ = ["router"]

--- a/app1/core/__init__.py
+++ b/app1/core/__init__.py
@@ -1,0 +1,1 @@
+"""Package initialisation for the rebuilt application."""

--- a/app1/core/config.py
+++ b/app1/core/config.py
@@ -1,0 +1,63 @@
+"""Application settings for the rebuilt architecture."""
+
+from functools import lru_cache
+from typing import Literal, Optional
+
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    """Configuration container for the new application stack."""
+
+    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8", extra="ignore")
+
+    environment: Literal["development", "preview", "production"] = Field(
+        default="development",
+        description="Deployment environment used for feature flags and logging.",
+    )
+    api_prefix: str = Field(default="/api", description="Root prefix for API routes.")
+    project_name: str = Field(default="ADHD Productivity App", description="Human friendly name.")
+
+    # Supabase configuration
+    supabase_url: str = Field(..., alias="SUPABASE_URL", description="Supabase project URL")
+    supabase_service_role_key: Optional[str] = Field(
+        None,
+        alias="SUPABASE_SERVICE_ROLE_KEY",
+        description="Service role key used for privileged server operations.",
+    )
+    supabase_anon_key: Optional[str] = Field(
+        None,
+        alias="SUPABASE_ANON_KEY",
+        description="Fallback key used in development when a service key is not provided.",
+    )
+    supabase_users_table: str = Field(
+        default="users",
+        description="Table name used to persist user profiles inside Supabase.",
+    )
+    supabase_tasks_table: str = Field(
+        default="tasks",
+        description="Table name for productivity tasks within Supabase.",
+    )
+
+    # Vercel specific configuration
+    vercel_project: Optional[str] = Field(
+        None,
+        alias="VERCEL_PROJECT",
+        description="Optional Vercel project name, used for metadata and logging.",
+    )
+    vercel_region: Optional[str] = Field(
+        None,
+        alias="VERCEL_REGION",
+        description="Vercel region hint for latency aware operations.",
+    )
+
+
+@lru_cache
+def get_settings() -> Settings:
+    """Return a cached instance of :class:`Settings`."""
+
+    return Settings()  # type: ignore[arg-type]
+
+
+__all__ = ["Settings", "get_settings"]

--- a/app1/core/exceptions.py
+++ b/app1/core/exceptions.py
@@ -1,0 +1,34 @@
+"""Exception hierarchy for the new application."""
+
+from fastapi import HTTPException, status
+
+
+class AppError(HTTPException):
+    """Base HTTP exception for the new application stack."""
+
+    def __init__(self, status_code: int = status.HTTP_400_BAD_REQUEST, detail: str = "App error") -> None:
+        super().__init__(status_code=status_code, detail=detail)
+
+
+class NotFoundError(AppError):
+    """Raised when a requested entity cannot be found."""
+
+    def __init__(self, detail: str = "Resource not found") -> None:
+        super().__init__(status.HTTP_404_NOT_FOUND, detail)
+
+
+class ConflictError(AppError):
+    """Raised when attempting to create a resource that already exists."""
+
+    def __init__(self, detail: str = "Resource conflict") -> None:
+        super().__init__(status.HTTP_409_CONFLICT, detail)
+
+
+class UnauthorizedError(AppError):
+    """Raised when authentication fails."""
+
+    def __init__(self, detail: str = "Unauthorized") -> None:
+        super().__init__(status.HTTP_401_UNAUTHORIZED, detail)
+
+
+__all__ = ["AppError", "NotFoundError", "ConflictError", "UnauthorizedError"]

--- a/app1/core/logging.py
+++ b/app1/core/logging.py
@@ -1,0 +1,21 @@
+"""Logging utilities tailored for the new application architecture."""
+
+import logging
+from typing import Optional
+
+from .config import Settings, get_settings
+
+
+def configure_logging(settings: Optional[Settings] = None) -> None:
+    """Configure a sane default logging setup for Vercel deployments."""
+
+    settings = settings or get_settings()
+    log_level = logging.INFO if settings.environment == "production" else logging.DEBUG
+
+    logging.basicConfig(
+        level=log_level,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    )
+
+
+__all__ = ["configure_logging"]

--- a/app1/domain/__init__.py
+++ b/app1/domain/__init__.py
@@ -1,0 +1,1 @@
+"""Package initialisation for the rebuilt application."""

--- a/app1/domain/tasks/__init__.py
+++ b/app1/domain/tasks/__init__.py
@@ -1,0 +1,1 @@
+"""Package initialisation for the rebuilt application."""

--- a/app1/domain/tasks/repository.py
+++ b/app1/domain/tasks/repository.py
@@ -1,0 +1,72 @@
+"""Supabase repository implementation for task entities."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+from uuid import UUID
+
+from supabase import Client
+
+from app.schemas.task_schema import TaskCreate, TaskResponse, TaskUpdate
+from app1.core.exceptions import AppError, NotFoundError
+
+
+class SupabaseTaskRepository:
+    """Handles task persistence against Supabase PostgREST endpoints."""
+
+    def __init__(self, client: Client, table: str) -> None:
+        self._client = client
+        self._table = table
+
+    def _execute_single(self, query: Any) -> Dict[str, Any]:
+        response = query.execute()
+        if getattr(response, "error", None):
+            raise AppError(detail=str(response.error))
+        if not response.data:
+            raise NotFoundError("Task not found")
+        if isinstance(response.data, list):
+            return response.data[0]
+        return response.data
+
+    def _execute_many(self, query: Any) -> List[Dict[str, Any]]:
+        response = query.execute()
+        if getattr(response, "error", None):
+            raise AppError(detail=str(response.error))
+        return response.data or []
+
+    def create_task(self, payload: TaskCreate) -> TaskResponse:
+        data = payload.model_dump(exclude_none=True)
+        query = self._client.table(self._table).insert(data).select("*")
+        record = self._execute_single(query)
+        return TaskResponse.model_validate(record)
+
+    def list_tasks_for_user(self, user_id: UUID) -> List[TaskResponse]:
+        query = self._client.table(self._table).select("*").eq("user_id", str(user_id))
+        records = self._execute_many(query)
+        return [TaskResponse.model_validate(record) for record in records]
+
+    def get_task(self, task_id: UUID) -> TaskResponse:
+        query = self._client.table(self._table).select("*").eq("id", str(task_id)).limit(1)
+        record = self._execute_single(query)
+        return TaskResponse.model_validate(record)
+
+    def update_task(self, task_id: UUID, payload: TaskUpdate) -> TaskResponse:
+        data = payload.model_dump(exclude_none=True)
+        if not data:
+            raise AppError(detail="No task fields supplied for update")
+        query = (
+            self._client.table(self._table)
+            .update(data)
+            .eq("id", str(task_id))
+            .select("*")
+            .limit(1)
+        )
+        record = self._execute_single(query)
+        return TaskResponse.model_validate(record)
+
+    def delete_task(self, task_id: UUID) -> None:
+        query = self._client.table(self._table).delete().eq("id", str(task_id)).limit(1)
+        self._execute_single(query)
+
+
+__all__ = ["SupabaseTaskRepository"]

--- a/app1/domain/users/__init__.py
+++ b/app1/domain/users/__init__.py
@@ -1,0 +1,1 @@
+"""Package initialisation for the rebuilt application."""

--- a/app1/domain/users/repository.py
+++ b/app1/domain/users/repository.py
@@ -1,0 +1,84 @@
+"""Persistence layer for user entities backed by Supabase."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+from uuid import UUID
+
+from fastapi import status
+from supabase import Client
+
+from app.schemas.user_schema import UserCreateSchema, UserResponseSchema, UserUpdateSchema
+from app1.core.exceptions import AppError, NotFoundError
+
+
+class SupabaseUserRepository:
+    """Repository responsible for persisting users inside Supabase."""
+
+    def __init__(self, client: Client, table: str) -> None:
+        self._client = client
+        self._table = table
+
+    def _execute_single(self, query: Any) -> Dict[str, Any]:
+        response = query.execute()
+        if getattr(response, "error", None):
+            raise AppError(detail=str(response.error))
+        if not response.data:
+            raise NotFoundError("User not found")
+        if isinstance(response.data, list):
+            return response.data[0]
+        return response.data
+
+    def _execute_many(self, query: Any) -> List[Dict[str, Any]]:
+        response = query.execute()
+        if getattr(response, "error", None):
+            raise AppError(detail=str(response.error))
+        return response.data or []
+
+    def create_user(self, payload: UserCreateSchema) -> UserResponseSchema:
+        user_dict = payload.model_dump(exclude_none=True)
+        query = self._client.table(self._table).insert(user_dict).select("*")
+        record = self._execute_single(query)
+        return UserResponseSchema.model_validate(record)
+
+    def get_user_by_id(self, user_id: UUID) -> UserResponseSchema:
+        query = self._client.table(self._table).select("*").eq("id", str(user_id)).limit(1)
+        record = self._execute_single(query)
+        return UserResponseSchema.model_validate(record)
+
+    def get_user_by_email(self, email: str) -> Optional[UserResponseSchema]:
+        query = self._client.table(self._table).select("*").eq("email", email).limit(1)
+        try:
+            record = self._execute_single(query)
+        except NotFoundError:
+            return None
+        return UserResponseSchema.model_validate(record)
+
+    def list_users(self) -> List[UserResponseSchema]:
+        query = self._client.table(self._table).select("*")
+        records = self._execute_many(query)
+        return [UserResponseSchema.model_validate(record) for record in records]
+
+    def update_user(self, user_id: UUID, payload: UserUpdateSchema) -> UserResponseSchema:
+        update_dict = payload.model_dump(exclude_none=True)
+        if not update_dict:
+            raise AppError(status.HTTP_400_BAD_REQUEST, "No fields provided for update")
+        query = (
+            self._client.table(self._table)
+            .update(update_dict)
+            .eq("id", str(user_id))
+            .select("*")
+            .limit(1)
+        )
+        record = self._execute_single(query)
+        return UserResponseSchema.model_validate(record)
+
+    def delete_user(self, user_id: UUID) -> None:
+        query = self._client.table(self._table).delete().eq("id", str(user_id)).limit(1)
+        try:
+            self._execute_single(query)
+        except NotFoundError as exc:
+            raise NotFoundError("User not found") from exc
+
+
+__all__ = ["SupabaseUserRepository"]

--- a/app1/infrastructure/__init__.py
+++ b/app1/infrastructure/__init__.py
@@ -1,0 +1,1 @@
+"""Package initialisation for the rebuilt application."""

--- a/app1/infrastructure/supabase_client.py
+++ b/app1/infrastructure/supabase_client.py
@@ -1,0 +1,41 @@
+"""Supabase client management for the new application."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import cached_property
+from typing import Optional
+
+from supabase import Client, create_client
+
+from app1.core.config import Settings
+
+
+@dataclass(slots=True)
+class SupabaseClientManager:
+    """Factory class that produces configured Supabase client instances."""
+
+    settings: Settings
+
+    @cached_property
+    def client(self) -> Client:
+        """Instantiate and cache a Supabase client."""
+
+        service_key = self.settings.supabase_service_role_key
+        key_to_use: Optional[str] = service_key or self.settings.supabase_anon_key
+        if not key_to_use:
+            msg = (
+                "A Supabase API key is required. Set SUPABASE_SERVICE_ROLE_KEY or SUPABASE_ANON_KEY."
+            )
+            raise RuntimeError(msg)
+
+        return create_client(self.settings.supabase_url, key_to_use)
+
+
+def get_supabase_client(settings: Settings) -> Client:
+    """Convenience helper to create a client from the provided settings."""
+
+    return SupabaseClientManager(settings).client
+
+
+__all__ = ["SupabaseClientManager", "get_supabase_client"]

--- a/app1/main.py
+++ b/app1/main.py
@@ -1,0 +1,22 @@
+"""ASGI application factory for the Supabase + Vercel stack."""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+from app1.api import create_api_router
+from app1.core.config import get_settings
+from app1.core.logging import configure_logging
+
+
+def create_app() -> FastAPI:
+    settings = get_settings()
+    configure_logging(settings)
+    application = FastAPI(title=settings.project_name, version="1.0.0")
+    application.include_router(create_api_router(), prefix=settings.api_prefix)
+    return application
+
+
+app = create_app()
+
+__all__ = ["create_app", "app"]

--- a/app1/services/__init__.py
+++ b/app1/services/__init__.py
@@ -1,0 +1,1 @@
+"""Package initialisation for the rebuilt application."""

--- a/app1/services/tasks.py
+++ b/app1/services/tasks.py
@@ -1,0 +1,33 @@
+"""Task service orchestrating Supabase-backed repositories with schema validation."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from app.schemas.task_schema import TaskCreate, TaskResponse, TaskUpdate
+from app1.domain.tasks.repository import SupabaseTaskRepository
+
+
+class TaskService:
+    """Provide task centric use-cases on top of Supabase persistence."""
+
+    def __init__(self, repository: SupabaseTaskRepository) -> None:
+        self._repository = repository
+
+    def create_task(self, payload: TaskCreate) -> TaskResponse:
+        return self._repository.create_task(payload)
+
+    def list_tasks(self, user_id: UUID) -> list[TaskResponse]:
+        return self._repository.list_tasks_for_user(user_id)
+
+    def get_task(self, task_id: UUID) -> TaskResponse:
+        return self._repository.get_task(task_id)
+
+    def update_task(self, task_id: UUID, payload: TaskUpdate) -> TaskResponse:
+        return self._repository.update_task(task_id, payload)
+
+    def delete_task(self, task_id: UUID) -> None:
+        self._repository.delete_task(task_id)
+
+
+__all__ = ["TaskService"]

--- a/app1/services/users.py
+++ b/app1/services/users.py
@@ -1,0 +1,41 @@
+"""User domain services for the Supabase-backed application."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from app.schemas.user_schema import UserCreateSchema, UserResponseSchema, UserUpdateSchema
+from app1.core.exceptions import ConflictError, NotFoundError
+from app1.domain.users.repository import SupabaseUserRepository
+
+
+class UserService:
+    """High level user orchestration that wraps the Supabase repository."""
+
+    def __init__(self, repository: SupabaseUserRepository) -> None:
+        self._repository = repository
+
+    def register_user(self, payload: UserCreateSchema) -> UserResponseSchema:
+        existing = self._repository.get_user_by_email(payload.email)
+        if existing:
+            raise ConflictError("A user with this email already exists")
+        return self._repository.create_user(payload)
+
+    def get_user(self, user_id: UUID) -> UserResponseSchema:
+        return self._repository.get_user_by_id(user_id)
+
+    def update_user(self, user_id: UUID, payload: UserUpdateSchema) -> UserResponseSchema:
+        self._repository.get_user_by_id(user_id)
+        return self._repository.update_user(user_id, payload)
+
+    def delete_user(self, user_id: UUID) -> None:
+        try:
+            self._repository.delete_user(user_id)
+        except NotFoundError as exc:
+            raise NotFoundError("User not found") from exc
+
+    def list_users(self) -> list[UserResponseSchema]:
+        return self._repository.list_users()
+
+
+__all__ = ["UserService"]

--- a/app1/utils/__init__.py
+++ b/app1/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Package initialisation for the rebuilt application."""

--- a/app1/vercel.py
+++ b/app1/vercel.py
@@ -1,0 +1,5 @@
+"""Entry point used by Vercel serverless deployments."""
+
+from app1.main import app  # noqa: F401
+
+__all__ = ["app"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,6 +29,7 @@ opentelemetry-instrumentation-fastapi>=0.40b0
 alembic>=1.12.1
 asyncpg>=0.29.0
 SQLAlchemy-Utils>=0.41.1
+supabase>=2.3.0
 
 # Calendar Integration
 google-auth-oauthlib>=1.0.0


### PR DESCRIPTION
## Summary
- create a new `app1` backend architecture tailored for Vercel hosting and Supabase persistence
- wire FastAPI routers for users, tasks, and health endpoints that reuse the existing schemas
- document the new stack and add configuration helpers, Supabase client utilities, and a Vercel entrypoint

## Testing
- python -m compileall app1

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f7e17c994832ab362fa491333acbb)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a new `app1` FastAPI stack tailored for Vercel, using Supabase for users/tasks with services, repositories, and routing.
> 
> - **Backend (app1)**:
>   - **FastAPI app**: Adds `app1/main.py` with app factory and router mounting; `app1/vercel.py` entrypoint for Vercel.
>   - **Configuration & Utilities**: Introduces `core` (`config`, `logging`, `exceptions`) and `infrastructure` (`supabase_client`) for env-driven settings and Supabase client management.
>   - **Domain & Services**:
>     - Users: `domain/users/repository.py` (Supabase-backed CRUD) and `services/users.py` (conflict/not-found handling).
>     - Tasks: `domain/tasks/repository.py` (Supabase-backed CRUD) and `services/tasks.py`.
>   - **API Routes**: `api/routes/users.py`, `api/routes/tasks.py`, and `api/routes/health.py` with dependency wiring via `api/dependencies.py` and router assembly in `api/__init__.py`.
>   - **Docs**: Adds `app1/README.md` with architecture, env vars, and deployment instructions.
> - **Dependencies**:
>   - Adds `supabase>=2.3.0` to `requirements.txt`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9306440e7e52de1652dfaee2c1ec2c5be647bb76. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->