### PR TITLE
Audit navigation tabs, context imports, API usage, and props

### DIFF
--- a/frontend/audits/navigation-usage-audit.md
+++ b/frontend/audits/navigation-usage-audit.md
@@ -1,0 +1,222 @@
+# Navigation, Tabs, Drawer, Context, API, and Props Audit
+
+## Scope
+
+This audit focuses on the current frontend navigation surface and the code paths it pulls in:
+
+- Expo Router layouts and route screens under `frontend/app`
+- Dashboard tab pages and tab content components
+- Any side-drawer/menu implementation references
+- Context hooks and providers used by those screens
+- Direct API route usage from pages/components/contexts/services
+- Props declared, props passed, and likely-unused props/imports
+- Generated export/database/schema noise that should not drive app logic
+
+For repeatable output as the app grows, run:
+
+```bash
+cd frontend
+npm run audit:navigation
+```
+
+This generates:
+
+- `frontend/audits/navigation-usage-report.md`
+- `frontend/audits/navigation-usage-report.json`
+
+Use the JSON report for consolidation work and the Markdown report for review comments.
+
+## Current navigation map
+
+### Root shell
+
+`frontend/app/_layout.tsx` currently wraps the app with:
+
+- `SafeAreaProvider`
+- `ThemeProvider`
+- `NotificationProvider`
+- root `Stack`
+
+It does **not** mount the same provider tree used in tests (`AuthProvider`, `TaskProvider`, `ADHDSettingsProvider`, `CalendarProvider`, `GamificationProvider`, `HyperfocusProvider`, `MentalHealthProvider`). Any screen using those contexts must be under another provider or it will fail at runtime.
+
+### Authenticated stack
+
+`frontend/app/(auth)/_layout.tsx` is the current authenticated route layout. It declares stack screens:
+
+- `index`
+- `mental-health`
+- `calendar-management`
+- `scheduling`
+- `calendar-settings`
+- `fidget/index`
+
+`fidget/index` is declared as a route but no matching `frontend/app/(auth)/fidget/index.tsx` file was found during review. The app does have dashboard-level `FidgetTab` components, so this is likely a stale route entry or a missing page.
+
+### Legacy/alternate tab shell
+
+`frontend/app/(app)/_layout.tsx` declares bottom tabs for:
+
+- `tasks`
+- `wellness`
+- `calendar`
+- `insights`
+
+However, matching route files for those tab names were not found in the review pass. This looks like a second navigation shell that should either become the canonical shell or be removed.
+
+### Dashboard inner tabs
+
+`frontend/app/(auth)/index.tsx` is the current dashboard and owns an RNEUI `Tab` plus `TabView` with five user-facing tabs:
+
+- Tasks
+- Wellness
+- Calendar
+- Insights
+- Fidget
+
+The dashboard imports both `InsightsTab` and `ADHDDashboard`, but the Insights `TabView.Item` renders `ADHDDashboard` rather than `InsightsTab`. Decide which component is canonical and remove the unused import/component path.
+
+### Side drawer / menu
+
+No live `Drawer.Screen` or side-drawer implementation was found in the current app route files during review. Existing navigation docs still reference drawer/menu update surfaces, so the next step is to either:
+
+1. add a real drawer from a single route registry, or
+2. remove drawer references from docs and stale code until the drawer exists.
+
+## Context/provider consolidation findings
+
+### Provider mismatch
+
+Tests mount a richer provider tree than the app root. Align the actual app root with the contexts used by live routes, or move feature routes under layouts that mount the required providers.
+
+Suggested canonical provider order:
+
+```tsx
+<SafeAreaProvider>
+  <ThemeProvider theme={theme}>
+    <AuthProvider>
+      <NotificationProvider>
+        <TaskProvider>
+          <CalendarProvider>
+            <MentalHealthProvider>
+              <HyperfocusProvider>
+                <GamificationProvider>
+                  {children}
+                </GamificationProvider>
+              </HyperfocusProvider>
+            </MentalHealthProvider>
+          </CalendarProvider>
+        </TaskProvider>
+      </NotificationProvider>
+    </AuthProvider>
+  </ThemeProvider>
+</SafeAreaProvider>
+```
+
+### Auth logic duplication
+
+`AuthContext` performs routing after auth initialization, and `(auth)/_layout.tsx` also redirects unauthenticated users. Pick one guard location.
+
+Recommendation: keep redirects in route layouts and make `AuthContext` state-only. This prevents context side effects from fighting route-level guards.
+
+### API client import drift
+
+Several files import `api` from `@/lib/api`, but the visible API client is `frontend/app/services/api.ts` and exports a default `api`. Consolidate into one client path, for example:
+
+```ts
+// frontend/lib/api.ts
+export { default as api } from '@/app/services/api';
+```
+
+or move the existing client to `frontend/lib/api.ts` and update imports.
+
+### Task logic split
+
+Task logic currently appears in at least four places:
+
+- `TaskContext`
+- `app/(auth)/tasks/index.tsx`
+- `app/(auth)/tasks/create.tsx`
+- `app/(auth)/tasks/[id].tsx`
+- `app/(auth)/calendar-management.tsx`
+
+The task index uses `TaskContext`, while create/edit/calendar management bypass it with direct `api`, `axios`, Redux, or `TaskService` usage. Pick one source of truth.
+
+Recommendation: route screens should call `TaskContext` actions, and `TaskContext` should call the task service/API client. Delete direct localhost axios calls from screens.
+
+## API route consistency findings
+
+API routes are mixed across direct localhost URLs, `/tasks`, and `/api/...` routes. Normalize all frontend calls to one API client and one route convention.
+
+Examples to consolidate:
+
+- `http://localhost:8000/tasks/${id}` in the task edit route
+- `http://localhost:8000/api/auth/register` in unauth register
+- `/tasks` in task create
+- `/api/calendar/events` in task create
+- `/api/hyperfocus/session` and `/api/hyperfocus/statistics` in hyperfocus context
+
+Recommended target:
+
+```ts
+api.get('/api/tasks')
+api.post('/api/tasks')
+api.put('/api/tasks/:id')
+api.post('/api/tasks/:id/complete')
+```
+
+If the backend truly exposes both `/tasks` and `/api/tasks`, add a small route map file and migrate one screen at a time.
+
+## Props/import cleanup findings
+
+Run the generated report for the complete list. Manual hotspots found during this review:
+
+- `app/(auth)/index.tsx`: `router`, `appTheme`, `showToast`, `recommendedActions`, and `InsightsTab` look unused or mismatched.
+- `app/(auth)/tasks/index.tsx`: `user`, `filter`, `setFilter`, `Button`, and `Badge` look stale; tasks are rendered directly from `tasks` instead of a filtered list.
+- `components/TaskCard.tsx`: `StartSessionRequest` and local `theme` look unused; `TaskCardProps` fields are used.
+- `app/(auth)/scheduling.tsx`: uses `Tabs.Screen` with `component` props inside a page and includes static 2024 schedule data. Convert this to nested Expo Router route files or a normal in-page tab component.
+- `app/(unauth)/login.tsx`: `Link href="/register"` should be checked against the current `(unauth)` group route convention.
+
+## Generated/db/schema noise candidates
+
+The audit script flags generated exports and dump-like files so they can be reviewed before deletion. Current obvious candidates include:
+
+- `frontend/frontend_consolidated_export.txt`
+- `frontend/app_export.txt`
+- `frontend/app_(auth)_export.txt`
+- `frontend/navigation_export.txt`
+- `frontend/screens_export.txt`
+
+These files are useful for snapshots, but they should not be imported, searched as source of truth, or used to decide live navigation behavior.
+
+## Consolidation plan
+
+1. Pick one shell: either `(auth)` stack plus dashboard inner tabs, or `(app)` bottom tabs. Remove the other after migration.
+2. Create a route registry for tab/drawer/menu items and derive UI from it.
+3. Move auth redirects into route layouts only.
+4. Mount the real provider tree in `app/_layout.tsx` or in the authenticated layout.
+5. Move all API calls through one API client and one route map.
+6. Move task create/edit/complete/delete through `TaskContext`.
+7. Delete generated export/db/schema noise after confirming the audit report and CI are clean.
+
+## Suggested route registry shape
+
+```ts
+type AppRoute = {
+  key: string;
+  title: string;
+  href: string;
+  icon: string;
+  surface: Array<'tab' | 'drawer' | 'dashboard'>;
+  requiresAuth: boolean;
+};
+
+export const APP_ROUTES: AppRoute[] = [
+  { key: 'tasks', title: 'Tasks', href: '/(auth)/tasks', icon: 'list-outline', surface: ['tab', 'drawer', 'dashboard'], requiresAuth: true },
+  { key: 'wellness', title: 'Wellness', href: '/(auth)/mental-health', icon: 'heart-outline', surface: ['tab', 'drawer', 'dashboard'], requiresAuth: true },
+  { key: 'calendar', title: 'Calendar', href: '/(auth)/calendar-management', icon: 'calendar-outline', surface: ['tab', 'drawer', 'dashboard'], requiresAuth: true },
+  { key: 'insights', title: 'Insights', href: '/(auth)', icon: 'analytics-outline', surface: ['tab', 'drawer', 'dashboard'], requiresAuth: true },
+  { key: 'settings', title: 'Settings', href: '/(auth)/calendar-settings', icon: 'settings-outline', surface: ['drawer'], requiresAuth: true },
+];
+```
+
+The audit script is intentionally independent of this registry, so it can keep reporting drift as new routes/components are added.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
     "web": "expo start --web",
     "test": "jest",
     "lint": "eslint \"**/*.{js,jsx,ts,tsx}\"",
+    "audit:navigation": "node scripts/audit-navigation-usage.mjs",
     "lint:fix": "eslint \"**/*.{js,jsx,ts,tsx}\" --fix",
     "fix:imports": "eslint \"**/*.{js,jsx,ts,tsx}\" --fix --rule 'import/order: [\"error\", {\"newlines-between\":\"always\",\"groups\":[\"builtin\",\"external\",\"internal\",\"parent\",\"sibling\",\"index\"]}]'",
     "clean": "rimraf node_modules package-lock.json && npm install",

--- a/frontend/scripts/audit-navigation-usage.mjs
+++ b/frontend/scripts/audit-navigation-usage.mjs
@@ -1,0 +1,658 @@
+#!/usr/bin/env node
+/*
+ * Audits Expo Router layouts, tab/dashboard components, context hook usage,
+ * API route usage, JSX props, and likely-unused imports across the frontend.
+ *
+ * Usage:
+ *   cd frontend && npm run audit:navigation
+ *   node scripts/audit-navigation-usage.mjs --print
+ *   node scripts/audit-navigation-usage.mjs ../frontend
+ */
+
+import fs from 'node:fs/promises';
+import fsSync from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+
+const SOURCE_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.jsx']);
+const ROUTE_LAYOUT_NAMES = new Set(['_layout.tsx', '_layout.ts', '_layout.jsx', '_layout.js']);
+const DEFAULT_SCAN_DIRS = [
+  'app',
+  'components',
+  'contexts',
+  'hooks',
+  'services',
+  'core',
+  'types',
+];
+
+const SKIP_DIRS = new Set([
+  '.git',
+  '.expo',
+  '.next',
+  'node_modules',
+  'coverage',
+  'dist',
+  'build',
+  'ios',
+  'android',
+]);
+
+const NOISE_FILE_PATTERNS = [
+  /(^|\/)frontend_consolidated_export\.txt$/,
+  /(^|\/)app_export\.txt$/,
+  /(^|\/)app_\(auth\)_export\.txt$/,
+  /(^|\/)navigation_export\.txt$/,
+  /(^|\/)screens_export\.txt$/,
+  /(^|\/)schema_dump/i,
+  /(^|\/)db_dump/i,
+  /(^|\/)database_dump/i,
+];
+
+function normalizePath(filePath) {
+  return filePath.split(path.sep).join('/');
+}
+
+function resolveFrontendRoot() {
+  const positional = process.argv.find(arg => !arg.startsWith('--') && arg !== process.argv[0] && arg !== process.argv[1]);
+  if (positional) {
+    return path.resolve(positional);
+  }
+
+  const cwd = process.cwd();
+  if (fsSync.existsSync(path.join(cwd, 'app')) && fsSync.existsSync(path.join(cwd, 'package.json'))) {
+    return cwd;
+  }
+
+  const nestedFrontend = path.join(cwd, 'frontend');
+  if (fsSync.existsSync(path.join(nestedFrontend, 'app')) && fsSync.existsSync(path.join(nestedFrontend, 'package.json'))) {
+    return nestedFrontend;
+  }
+
+  return cwd;
+}
+
+async function pathExists(candidate) {
+  try {
+    await fs.access(candidate);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function walkFiles(rootDir, relativeDir = '') {
+  const absoluteDir = path.join(rootDir, relativeDir);
+  if (!await pathExists(absoluteDir)) return [];
+
+  const entries = await fs.readdir(absoluteDir, { withFileTypes: true });
+  const files = [];
+
+  for (const entry of entries) {
+    if (entry.name.startsWith('.') && entry.name !== '.expo') continue;
+    const nextRelative = path.join(relativeDir, entry.name);
+
+    if (entry.isDirectory()) {
+      if (SKIP_DIRS.has(entry.name)) continue;
+      files.push(...await walkFiles(rootDir, nextRelative));
+    } else {
+      files.push(normalizePath(nextRelative));
+    }
+  }
+
+  return files;
+}
+
+async function collectFiles(frontendRoot) {
+  const fileSet = new Set();
+  for (const dir of DEFAULT_SCAN_DIRS) {
+    for (const file of await walkFiles(frontendRoot, dir)) {
+      fileSet.add(file);
+    }
+  }
+  return [...fileSet].sort();
+}
+
+function stripImportBlocks(source) {
+  return source
+    .replace(/import\s+type\s+[\s\S]*?from\s+['"][^'"]+['"];?/g, '')
+    .replace(/import\s+[\s\S]*?from\s+['"][^'"]+['"];?/g, '')
+    .replace(/import\s+['"][^'"]+['"];?/g, '');
+}
+
+function countIdentifierUsages(source, identifier) {
+  if (!identifier) return 0;
+  const escaped = identifier.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const matches = source.match(new RegExp(`\\b${escaped}\\b`, 'g'));
+  return matches?.length ?? 0;
+}
+
+function parseImportLocals(clause) {
+  if (!clause) return [];
+
+  const cleaned = clause
+    .replace(/^type\s+/, '')
+    .replace(/\n/g, ' ')
+    .trim();
+
+  const locals = [];
+
+  const namespaceMatch = cleaned.match(/\*\s+as\s+([A-Za-z_$][\w$]*)/);
+  if (namespaceMatch) locals.push(namespaceMatch[1]);
+
+  const namedMatch = cleaned.match(/\{([^}]*)\}/);
+  if (namedMatch) {
+    const named = namedMatch[1]
+      .split(',')
+      .map(part => part.trim())
+      .filter(Boolean)
+      .map(part => {
+        const alias = part.match(/\bas\s+([A-Za-z_$][\w$]*)$/);
+        if (alias) return alias[1];
+        return part.replace(/^type\s+/, '').split(/\s+/)[0];
+      })
+      .filter(Boolean);
+    locals.push(...named);
+  }
+
+  const withoutNamed = cleaned.replace(/\{[^}]*\}/g, '').replace(/\*\s+as\s+[A-Za-z_$][\w$]*/g, '');
+  const defaultCandidate = withoutNamed.split(',')[0]?.trim();
+  if (defaultCandidate && /^[A-Za-z_$][\w$]*$/.test(defaultCandidate)) {
+    locals.push(defaultCandidate);
+  }
+
+  return [...new Set(locals)];
+}
+
+function parseImports(file, source) {
+  const imports = [];
+  const importRegex = /import\s+(type\s+)?(?:(?<clause>[\s\S]*?)\s+from\s+)?['"](?<specifier>[^'"]+)['"];?/g;
+  let match;
+
+  while ((match = importRegex.exec(source)) !== null) {
+    const clause = match.groups?.clause ?? '';
+    imports.push({
+      file,
+      specifier: match.groups?.specifier ?? '',
+      typeOnly: Boolean(match[1]),
+      locals: parseImportLocals(clause),
+      line: lineNumberForIndex(source, match.index),
+    });
+  }
+
+  return imports;
+}
+
+function lineNumberForIndex(source, index) {
+  return source.slice(0, index).split('\n').length;
+}
+
+function parseApiCalls(file, source) {
+  const calls = [];
+  const apiRegex = /\b(?<client>api|axios)\s*(?:\.\s*(?<method>get|post|put|patch|delete|request))?\s*(?:<[^>]+>)?\s*\(\s*(?<quote>['"`])(?<route>[\s\S]*?)(?<quoteClose>['"`])/g;
+  const fetchRegex = /\bfetch\s*\(\s*(?<quote>['"`])(?<route>[\s\S]*?)(?<quoteClose>['"`])/g;
+
+  let match;
+  while ((match = apiRegex.exec(source)) !== null) {
+    calls.push({
+      file,
+      client: match.groups.client,
+      method: match.groups.method ?? 'call',
+      route: match.groups.route,
+      line: lineNumberForIndex(source, match.index),
+    });
+  }
+
+  while ((match = fetchRegex.exec(source)) !== null) {
+    calls.push({
+      file,
+      client: 'fetch',
+      method: 'call',
+      route: match.groups.route,
+      line: lineNumberForIndex(source, match.index),
+    });
+  }
+
+  return calls;
+}
+
+function parseContextHooks(file, source) {
+  const hooks = [];
+  const hookRegex = /\b(?<hook>use[A-Z][A-Za-z0-9_]*)\s*\(/g;
+  let match;
+  while ((match = hookRegex.exec(source)) !== null) {
+    const hook = match.groups.hook;
+    if (['useState', 'useEffect', 'useCallback', 'useMemo', 'useRef', 'useReducer', 'useContext'].includes(hook)) {
+      continue;
+    }
+    hooks.push({ file, hook, line: lineNumberForIndex(source, match.index) });
+  }
+  return hooks;
+}
+
+function routeCandidatesForScreen(layoutFile, screenName) {
+  const baseDir = path.posix.dirname(layoutFile);
+  const normalizedName = screenName.replace(/^\.\//, '').replace(/\/index$/, '/index');
+  const base = normalizedName === 'index'
+    ? path.posix.join(baseDir, 'index')
+    : path.posix.join(baseDir, normalizedName);
+
+  const candidates = [];
+  for (const ext of SOURCE_EXTENSIONS) {
+    candidates.push(`${base}${ext}`);
+  }
+  for (const ext of SOURCE_EXTENSIONS) {
+    candidates.push(`${base}/index${ext}`);
+  }
+  for (const ext of SOURCE_EXTENSIONS) {
+    candidates.push(`${base}/_layout${ext}`);
+  }
+  return candidates;
+}
+
+function parseExpoRouterScreens(file, source, allSourceFiles) {
+  if (!ROUTE_LAYOUT_NAMES.has(path.posix.basename(file))) return [];
+
+  const screens = [];
+  const screenRegex = /<(?<navigator>Stack|Tabs|Drawer)\.Screen\b[\s\S]*?\bname=(?<quote>['"`])(?<name>[^'"`]+)(?<quoteClose>['"`])[\s\S]*?>/g;
+  let match;
+
+  while ((match = screenRegex.exec(source)) !== null) {
+    const name = match.groups.name;
+    const candidates = routeCandidatesForScreen(file, name);
+    const resolved = candidates.find(candidate => allSourceFiles.has(candidate));
+    screens.push({
+      file,
+      navigator: match.groups.navigator,
+      name,
+      line: lineNumberForIndex(source, match.index),
+      resolved: resolved ?? null,
+      candidates,
+    });
+  }
+
+  return screens;
+}
+
+function parseInnerTabs(file, source) {
+  const tabs = [];
+  const tabItemRegex = /<Tab\.Item\b[\s\S]*?\btitle=(?<quote>['"`])(?<title>[^'"`]+)(?<quoteClose>['"`])[\s\S]*?>/g;
+  const tabViewRegex = /<TabView\.Item\b/g;
+  let match;
+
+  while ((match = tabItemRegex.exec(source)) !== null) {
+    tabs.push({
+      file,
+      kind: 'Tab.Item',
+      title: match.groups.title,
+      line: lineNumberForIndex(source, match.index),
+    });
+  }
+
+  while ((match = tabViewRegex.exec(source)) !== null) {
+    tabs.push({
+      file,
+      kind: 'TabView.Item',
+      title: null,
+      line: lineNumberForIndex(source, match.index),
+    });
+  }
+
+  return tabs;
+}
+
+function parseNavigationCalls(file, source) {
+  const calls = [];
+  const routerRegex = /\brouter\.(?<method>push|replace|back|navigate)\s*\(\s*(?<arg>[^)\n]+)/g;
+  const linkRegex = /<Link\b[\s\S]*?\bhref=(?<quote>['"`])(?<href>[^'"`]+)(?<quoteClose>['"`])/g;
+  let match;
+
+  while ((match = routerRegex.exec(source)) !== null) {
+    calls.push({
+      file,
+      type: 'router',
+      method: match.groups.method,
+      target: match.groups.arg.trim(),
+      line: lineNumberForIndex(source, match.index),
+    });
+  }
+
+  while ((match = linkRegex.exec(source)) !== null) {
+    calls.push({
+      file,
+      type: 'Link',
+      method: 'href',
+      target: match.groups.href,
+      line: lineNumberForIndex(source, match.index),
+    });
+  }
+
+  return calls;
+}
+
+function parsePropsDeclarations(file, source) {
+  const declarations = [];
+  const interfaceRegex = /interface\s+(?<name>[A-Za-z_$][\w$]*Props)\s*(?:extends\s+[^{]+)?\{(?<body>[\s\S]*?)\n\}/g;
+  const typeRegex = /type\s+(?<name>[A-Za-z_$][\w$]*Props)\s*=\s*\{(?<body>[\s\S]*?)\n\}/g;
+
+  for (const regex of [interfaceRegex, typeRegex]) {
+    let match;
+    while ((match = regex.exec(source)) !== null) {
+      const fields = match.groups.body
+        .split('\n')
+        .map(line => line.trim())
+        .map(line => line.match(/^([A-Za-z_$][\w$]*)\??\s*:/)?.[1])
+        .filter(Boolean);
+      declarations.push({
+        file,
+        name: match.groups.name,
+        fields: [...new Set(fields)],
+        line: lineNumberForIndex(source, match.index),
+      });
+    }
+  }
+
+  return declarations;
+}
+
+function parseJsxProps(file, source) {
+  const usages = [];
+  const jsxRegex = /<(?<component>[A-Z][A-Za-z0-9_.]*)\b(?<attrs>[^<>]*?)(?:\/?>)/g;
+  let match;
+
+  while ((match = jsxRegex.exec(source)) !== null) {
+    const attrs = match.groups.attrs ?? '';
+    const props = [];
+    const propRegex = /(?:^|\s)(?<name>[A-Za-z_$][\w$-]*)(?:\s*=|\s|$)/g;
+    let propMatch;
+    while ((propMatch = propRegex.exec(attrs)) !== null) {
+      const propName = propMatch.groups.name;
+      if (!['key', 'style', 'children'].includes(propName)) props.push(propName);
+    }
+
+    if (props.length > 0) {
+      usages.push({
+        file,
+        component: match.groups.component,
+        props: [...new Set(props)].sort(),
+        line: lineNumberForIndex(source, match.index),
+      });
+    }
+  }
+
+  return usages;
+}
+
+function likelyUnusedImports(file, source, imports) {
+  const withoutImports = stripImportBlocks(source);
+  const unused = [];
+
+  for (const importEntry of imports) {
+    for (const local of importEntry.locals) {
+      if (countIdentifierUsages(withoutImports, local) === 0) {
+        unused.push({
+          file,
+          local,
+          specifier: importEntry.specifier,
+          line: importEntry.line,
+          confidence: importEntry.typeOnly ? 'medium' : 'high',
+        });
+      }
+    }
+  }
+
+  return unused;
+}
+
+function groupBy(items, keyFn) {
+  const grouped = new Map();
+  for (const item of items) {
+    const key = keyFn(item);
+    if (!grouped.has(key)) grouped.set(key, []);
+    grouped.get(key).push(item);
+  }
+  return Object.fromEntries(grouped.entries());
+}
+
+function summarizeImports(imports) {
+  return Object.entries(groupBy(imports, item => item.specifier))
+    .map(([specifier, entries]) => ({
+      specifier,
+      count: entries.length,
+      files: [...new Set(entries.map(entry => entry.file))].sort(),
+    }))
+    .sort((a, b) => b.count - a.count || a.specifier.localeCompare(b.specifier));
+}
+
+function summarizeApiCalls(apiCalls) {
+  return Object.entries(groupBy(apiCalls, item => `${item.client}.${item.method} ${item.route}`))
+    .map(([signature, entries]) => ({
+      signature,
+      count: entries.length,
+      files: entries.map(entry => `${entry.file}:${entry.line}`).sort(),
+    }))
+    .sort((a, b) => b.count - a.count || a.signature.localeCompare(b.signature));
+}
+
+function summarizeContextHooks(hooks) {
+  return Object.entries(groupBy(hooks, item => item.hook))
+    .map(([hook, entries]) => ({
+      hook,
+      count: entries.length,
+      files: entries.map(entry => `${entry.file}:${entry.line}`).sort(),
+    }))
+    .sort((a, b) => b.count - a.count || a.hook.localeCompare(b.hook));
+}
+
+function noiseFiles(allFiles) {
+  return allFiles.filter(file => NOISE_FILE_PATTERNS.some(pattern => pattern.test(file))).sort();
+}
+
+function makeMarkdownReport(report) {
+  const missingScreens = report.routeScreens.filter(screen => !screen.resolved);
+  const lines = [];
+
+  lines.push('# Navigation Usage Audit');
+  lines.push('');
+  lines.push(`Generated at: ${new Date(report.generatedAt).toISOString()}`);
+  lines.push(`Frontend root: \`${report.frontendRoot}\``);
+  lines.push('');
+  lines.push('## Summary');
+  lines.push('');
+  lines.push(`- Source files scanned: ${report.summary.sourceFiles}`);
+  lines.push(`- Imports found: ${report.summary.imports}`);
+  lines.push(`- Expo Router screen declarations: ${report.summary.routeScreens}`);
+  lines.push(`- Missing/unresolved route screen targets: ${missingScreens.length}`);
+  lines.push(`- Inner dashboard tab declarations: ${report.summary.innerTabs}`);
+  lines.push(`- Navigation calls: ${report.summary.navigationCalls}`);
+  lines.push(`- Context hook usages: ${report.summary.contextHooks}`);
+  lines.push(`- API calls: ${report.summary.apiCalls}`);
+  lines.push(`- Props declarations: ${report.summary.propDeclarations}`);
+  lines.push(`- JSX prop usage sites: ${report.summary.jsxPropUsages}`);
+  lines.push(`- Likely-unused imports: ${report.summary.likelyUnusedImports}`);
+  lines.push(`- Generated/export/db/schema noise candidates: ${report.summary.noiseCandidates}`);
+  lines.push('');
+
+  lines.push('## Expo Router Screens');
+  lines.push('');
+  for (const screen of report.routeScreens) {
+    lines.push(`- \`${screen.file}:${screen.line}\` ${screen.navigator}.Screen \`${screen.name}\` -> ${screen.resolved ? `\`${screen.resolved}\`` : '**missing target**'}`);
+  }
+  if (report.routeScreens.length === 0) lines.push('- No Expo Router screen declarations found.');
+  lines.push('');
+
+  if (missingScreens.length > 0) {
+    lines.push('## Missing Route Targets');
+    lines.push('');
+    for (const screen of missingScreens) {
+      lines.push(`- \`${screen.file}:${screen.line}\` declares \`${screen.name}\`; checked: ${screen.candidates.map(candidate => `\`${candidate}\``).join(', ')}`);
+    }
+    lines.push('');
+  }
+
+  lines.push('## Inner Tabs / TabView');
+  lines.push('');
+  for (const tab of report.innerTabs) {
+    lines.push(`- \`${tab.file}:${tab.line}\` ${tab.kind}${tab.title ? ` \`${tab.title}\`` : ''}`);
+  }
+  if (report.innerTabs.length === 0) lines.push('- No RNEUI Tab or TabView items found.');
+  lines.push('');
+
+  lines.push('## Navigation Calls');
+  lines.push('');
+  for (const call of report.navigationCalls) {
+    lines.push(`- \`${call.file}:${call.line}\` ${call.type}.${call.method} -> \`${call.target}\``);
+  }
+  if (report.navigationCalls.length === 0) lines.push('- No router/Link navigation calls found.');
+  lines.push('');
+
+  lines.push('## Context Hook Usage');
+  lines.push('');
+  for (const hook of report.contextHookSummary) {
+    lines.push(`- \`${hook.hook}\` (${hook.count}): ${hook.files.map(file => `\`${file}\``).join(', ')}`);
+  }
+  if (report.contextHookSummary.length === 0) lines.push('- No non-core hooks found.');
+  lines.push('');
+
+  lines.push('## API Calls');
+  lines.push('');
+  for (const api of report.apiSummary) {
+    lines.push(`- \`${api.signature}\` (${api.count}): ${api.files.map(file => `\`${file}\``).join(', ')}`);
+  }
+  if (report.apiSummary.length === 0) lines.push('- No direct API calls found.');
+  lines.push('');
+
+  lines.push('## Props Declared by Components');
+  lines.push('');
+  for (const declaration of report.propDeclarations) {
+    lines.push(`- \`${declaration.file}:${declaration.line}\` ${declaration.name}: ${declaration.fields.map(field => `\`${field}\``).join(', ') || '_no fields parsed_'}`);
+  }
+  if (report.propDeclarations.length === 0) lines.push('- No Props interfaces/types found.');
+  lines.push('');
+
+  lines.push('## JSX Prop Usage Sites');
+  lines.push('');
+  for (const usage of report.jsxPropUsages) {
+    lines.push(`- \`${usage.file}:${usage.line}\` <${usage.component}>: ${usage.props.map(prop => `\`${prop}\``).join(', ')}`);
+  }
+  if (report.jsxPropUsages.length === 0) lines.push('- No JSX prop usage sites found.');
+  lines.push('');
+
+  lines.push('## Likely-Unused Imports');
+  lines.push('');
+  lines.push('This is a regex-based signal. Confirm with TypeScript/ESLint before deleting.');
+  lines.push('');
+  for (const unused of report.likelyUnusedImports) {
+    lines.push(`- \`${unused.file}:${unused.line}\` \`${unused.local}\` from \`${unused.specifier}\` (${unused.confidence})`);
+  }
+  if (report.likelyUnusedImports.length === 0) lines.push('- No likely-unused imports found by this heuristic.');
+  lines.push('');
+
+  lines.push('## Import Summary');
+  lines.push('');
+  for (const item of report.importSummary.slice(0, 80)) {
+    lines.push(`- \`${item.specifier}\` (${item.count} files)`);
+  }
+  if (report.importSummary.length > 80) {
+    lines.push(`- ...and ${report.importSummary.length - 80} more import specifiers. See JSON for full output.`);
+  }
+  if (report.importSummary.length === 0) lines.push('- No imports found.');
+  lines.push('');
+
+  lines.push('## Noise Candidates');
+  lines.push('');
+  lines.push('These are generated exports, dumps, or schema/db artifacts that should not drive navigation logic. Review before deletion.');
+  lines.push('');
+  for (const file of report.noiseCandidates) {
+    lines.push(`- \`${file}\``);
+  }
+  if (report.noiseCandidates.length === 0) lines.push('- No obvious generated export/db/schema noise candidates found.');
+  lines.push('');
+
+  return `${lines.join('\n')}\n`;
+}
+
+async function main() {
+  const frontendRoot = resolveFrontendRoot();
+  const sourceFiles = await collectFiles(frontendRoot);
+  const allFiles = await walkFiles(frontendRoot);
+  const allSourceFileSet = new Set(sourceFiles.filter(file => SOURCE_EXTENSIONS.has(path.extname(file))));
+
+  const imports = [];
+  const apiCalls = [];
+  const contextHooks = [];
+  const routeScreens = [];
+  const innerTabs = [];
+  const navigationCalls = [];
+  const propDeclarations = [];
+  const jsxPropUsages = [];
+  const likelyUnused = [];
+
+  for (const file of sourceFiles) {
+    if (!SOURCE_EXTENSIONS.has(path.extname(file))) continue;
+    const absolute = path.join(frontendRoot, file);
+    const source = await fs.readFile(absolute, 'utf8');
+    const fileImports = parseImports(file, source);
+
+    imports.push(...fileImports);
+    apiCalls.push(...parseApiCalls(file, source));
+    contextHooks.push(...parseContextHooks(file, source));
+    routeScreens.push(...parseExpoRouterScreens(file, source, allSourceFileSet));
+    innerTabs.push(...parseInnerTabs(file, source));
+    navigationCalls.push(...parseNavigationCalls(file, source));
+    propDeclarations.push(...parsePropsDeclarations(file, source));
+    jsxPropUsages.push(...parseJsxProps(file, source));
+    likelyUnused.push(...likelyUnusedImports(file, source, fileImports));
+  }
+
+  const report = {
+    generatedAt: new Date().toISOString(),
+    frontendRoot: normalizePath(frontendRoot),
+    summary: {
+      sourceFiles: allSourceFileSet.size,
+      imports: imports.length,
+      routeScreens: routeScreens.length,
+      innerTabs: innerTabs.length,
+      navigationCalls: navigationCalls.length,
+      contextHooks: contextHooks.length,
+      apiCalls: apiCalls.length,
+      propDeclarations: propDeclarations.length,
+      jsxPropUsages: jsxPropUsages.length,
+      likelyUnusedImports: likelyUnused.length,
+      noiseCandidates: noiseFiles(allFiles).length,
+    },
+    routeScreens,
+    innerTabs,
+    navigationCalls,
+    contextHookSummary: summarizeContextHooks(contextHooks),
+    contextHooks,
+    apiSummary: summarizeApiCalls(apiCalls),
+    apiCalls,
+    propDeclarations,
+    jsxPropUsages,
+    likelyUnusedImports: likelyUnused.sort((a, b) => a.file.localeCompare(b.file) || a.line - b.line),
+    importSummary: summarizeImports(imports),
+    imports,
+    noiseCandidates: noiseFiles(allFiles),
+  };
+
+  const markdown = makeMarkdownReport(report);
+
+  if (process.argv.includes('--print')) {
+    process.stdout.write(markdown);
+    return;
+  }
+
+  const auditsDir = path.join(frontendRoot, 'audits');
+  await fs.mkdir(auditsDir, { recursive: true });
+  await fs.writeFile(path.join(auditsDir, 'navigation-usage-report.json'), `${JSON.stringify(report, null, 2)}\n`);
+  await fs.writeFile(path.join(auditsDir, 'navigation-usage-report.md'), markdown);
+
+  console.log(`Navigation usage audit written to ${normalizePath(path.join(auditsDir, 'navigation-usage-report.md'))}`);
+  console.log(`JSON audit written to ${normalizePath(path.join(auditsDir, 'navigation-usage-report.json'))}`);
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/frontend/scripts/audit-navigation-usage.mjs
+++ b/frontend/scripts/audit-navigation-usage.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /*
  * Audits Expo Router layouts, tab/dashboard components, context hook usage,
- * API route usage, JSX props, and likely-unused imports across the frontend.
+ * API route usage, JSX props, likely-unused props, and likely-unused imports.
  *
  * Usage:
  *   cd frontend && npm run audit:navigation
@@ -24,6 +24,12 @@ const DEFAULT_SCAN_DIRS = [
   'services',
   'core',
   'types',
+  'navigation',
+  'screens',
+  'constants',
+  'utils',
+  'theme',
+  'lib',
 ];
 
 const SKIP_DIRS = new Set([
@@ -47,6 +53,7 @@ const NOISE_FILE_PATTERNS = [
   /(^|\/)schema_dump/i,
   /(^|\/)db_dump/i,
   /(^|\/)database_dump/i,
+  /(^|\/).+_export\.txt$/,
 ];
 
 function normalizePath(filePath) {
@@ -55,19 +62,13 @@ function normalizePath(filePath) {
 
 function resolveFrontendRoot() {
   const positional = process.argv.find(arg => !arg.startsWith('--') && arg !== process.argv[0] && arg !== process.argv[1]);
-  if (positional) {
-    return path.resolve(positional);
-  }
+  if (positional) return path.resolve(positional);
 
   const cwd = process.cwd();
-  if (fsSync.existsSync(path.join(cwd, 'app')) && fsSync.existsSync(path.join(cwd, 'package.json'))) {
-    return cwd;
-  }
+  if (fsSync.existsSync(path.join(cwd, 'app')) && fsSync.existsSync(path.join(cwd, 'package.json'))) return cwd;
 
   const nestedFrontend = path.join(cwd, 'frontend');
-  if (fsSync.existsSync(path.join(nestedFrontend, 'app')) && fsSync.existsSync(path.join(nestedFrontend, 'package.json'))) {
-    return nestedFrontend;
-  }
+  if (fsSync.existsSync(path.join(nestedFrontend, 'app')) && fsSync.existsSync(path.join(nestedFrontend, 'package.json'))) return nestedFrontend;
 
   return cwd;
 }
@@ -106,9 +107,7 @@ async function walkFiles(rootDir, relativeDir = '') {
 async function collectFiles(frontendRoot) {
   const fileSet = new Set();
   for (const dir of DEFAULT_SCAN_DIRS) {
-    for (const file of await walkFiles(frontendRoot, dir)) {
-      fileSet.add(file);
-    }
+    for (const file of await walkFiles(frontendRoot, dir)) fileSet.add(file);
   }
   return [...fileSet].sort();
 }
@@ -127,14 +126,14 @@ function countIdentifierUsages(source, identifier) {
   return matches?.length ?? 0;
 }
 
+function lineNumberForIndex(source, index) {
+  return source.slice(0, index).split('\n').length;
+}
+
 function parseImportLocals(clause) {
   if (!clause) return [];
 
-  const cleaned = clause
-    .replace(/^type\s+/, '')
-    .replace(/\n/g, ' ')
-    .trim();
-
+  const cleaned = clause.replace(/^type\s+/, '').replace(/\n/g, ' ').trim();
   const locals = [];
 
   const namespaceMatch = cleaned.match(/\*\s+as\s+([A-Za-z_$][\w$]*)/);
@@ -142,7 +141,7 @@ function parseImportLocals(clause) {
 
   const namedMatch = cleaned.match(/\{([^}]*)\}/);
   if (namedMatch) {
-    const named = namedMatch[1]
+    locals.push(...namedMatch[1]
       .split(',')
       .map(part => part.trim())
       .filter(Boolean)
@@ -151,15 +150,12 @@ function parseImportLocals(clause) {
         if (alias) return alias[1];
         return part.replace(/^type\s+/, '').split(/\s+/)[0];
       })
-      .filter(Boolean);
-    locals.push(...named);
+      .filter(Boolean));
   }
 
   const withoutNamed = cleaned.replace(/\{[^}]*\}/g, '').replace(/\*\s+as\s+[A-Za-z_$][\w$]*/g, '');
   const defaultCandidate = withoutNamed.split(',')[0]?.trim();
-  if (defaultCandidate && /^[A-Za-z_$][\w$]*$/.test(defaultCandidate)) {
-    locals.push(defaultCandidate);
-  }
+  if (defaultCandidate && /^[A-Za-z_$][\w$]*$/.test(defaultCandidate)) locals.push(defaultCandidate);
 
   return [...new Set(locals)];
 }
@@ -170,21 +166,16 @@ function parseImports(file, source) {
   let match;
 
   while ((match = importRegex.exec(source)) !== null) {
-    const clause = match.groups?.clause ?? '';
     imports.push({
       file,
       specifier: match.groups?.specifier ?? '',
       typeOnly: Boolean(match[1]),
-      locals: parseImportLocals(clause),
+      locals: parseImportLocals(match.groups?.clause ?? ''),
       line: lineNumberForIndex(source, match.index),
     });
   }
 
   return imports;
-}
-
-function lineNumberForIndex(source, index) {
-  return source.slice(0, index).split('\n').length;
 }
 
 function parseApiCalls(file, source) {
@@ -194,23 +185,11 @@ function parseApiCalls(file, source) {
 
   let match;
   while ((match = apiRegex.exec(source)) !== null) {
-    calls.push({
-      file,
-      client: match.groups.client,
-      method: match.groups.method ?? 'call',
-      route: match.groups.route,
-      line: lineNumberForIndex(source, match.index),
-    });
+    calls.push({ file, client: match.groups.client, method: match.groups.method ?? 'call', route: match.groups.route, line: lineNumberForIndex(source, match.index) });
   }
 
   while ((match = fetchRegex.exec(source)) !== null) {
-    calls.push({
-      file,
-      client: 'fetch',
-      method: 'call',
-      route: match.groups.route,
-      line: lineNumberForIndex(source, match.index),
-    });
+    calls.push({ file, client: 'fetch', method: 'call', route: match.groups.route, line: lineNumberForIndex(source, match.index) });
   }
 
   return calls;
@@ -218,35 +197,27 @@ function parseApiCalls(file, source) {
 
 function parseContextHooks(file, source) {
   const hooks = [];
+  const coreHooks = new Set(['useState', 'useEffect', 'useCallback', 'useMemo', 'useRef', 'useReducer', 'useContext', 'useImperativeHandle', 'useLayoutEffect']);
   const hookRegex = /\b(?<hook>use[A-Z][A-Za-z0-9_]*)\s*\(/g;
   let match;
+
   while ((match = hookRegex.exec(source)) !== null) {
     const hook = match.groups.hook;
-    if (['useState', 'useEffect', 'useCallback', 'useMemo', 'useRef', 'useReducer', 'useContext'].includes(hook)) {
-      continue;
-    }
-    hooks.push({ file, hook, line: lineNumberForIndex(source, match.index) });
+    if (!coreHooks.has(hook)) hooks.push({ file, hook, line: lineNumberForIndex(source, match.index) });
   }
+
   return hooks;
 }
 
 function routeCandidatesForScreen(layoutFile, screenName) {
   const baseDir = path.posix.dirname(layoutFile);
   const normalizedName = screenName.replace(/^\.\//, '').replace(/\/index$/, '/index');
-  const base = normalizedName === 'index'
-    ? path.posix.join(baseDir, 'index')
-    : path.posix.join(baseDir, normalizedName);
+  const base = normalizedName === 'index' ? path.posix.join(baseDir, 'index') : path.posix.join(baseDir, normalizedName);
 
   const candidates = [];
-  for (const ext of SOURCE_EXTENSIONS) {
-    candidates.push(`${base}${ext}`);
-  }
-  for (const ext of SOURCE_EXTENSIONS) {
-    candidates.push(`${base}/index${ext}`);
-  }
-  for (const ext of SOURCE_EXTENSIONS) {
-    candidates.push(`${base}/_layout${ext}`);
-  }
+  for (const ext of SOURCE_EXTENSIONS) candidates.push(`${base}${ext}`);
+  for (const ext of SOURCE_EXTENSIONS) candidates.push(`${base}/index${ext}`);
+  for (const ext of SOURCE_EXTENSIONS) candidates.push(`${base}/_layout${ext}`);
   return candidates;
 }
 
@@ -261,14 +232,7 @@ function parseExpoRouterScreens(file, source, allSourceFiles) {
     const name = match.groups.name;
     const candidates = routeCandidatesForScreen(file, name);
     const resolved = candidates.find(candidate => allSourceFiles.has(candidate));
-    screens.push({
-      file,
-      navigator: match.groups.navigator,
-      name,
-      line: lineNumberForIndex(source, match.index),
-      resolved: resolved ?? null,
-      candidates,
-    });
+    screens.push({ file, navigator: match.groups.navigator, name, line: lineNumberForIndex(source, match.index), resolved: resolved ?? null, candidates });
   }
 
   return screens;
@@ -281,21 +245,11 @@ function parseInnerTabs(file, source) {
   let match;
 
   while ((match = tabItemRegex.exec(source)) !== null) {
-    tabs.push({
-      file,
-      kind: 'Tab.Item',
-      title: match.groups.title,
-      line: lineNumberForIndex(source, match.index),
-    });
+    tabs.push({ file, kind: 'Tab.Item', title: match.groups.title, line: lineNumberForIndex(source, match.index) });
   }
 
   while ((match = tabViewRegex.exec(source)) !== null) {
-    tabs.push({
-      file,
-      kind: 'TabView.Item',
-      title: null,
-      line: lineNumberForIndex(source, match.index),
-    });
+    tabs.push({ file, kind: 'TabView.Item', title: null, line: lineNumberForIndex(source, match.index) });
   }
 
   return tabs;
@@ -308,23 +262,11 @@ function parseNavigationCalls(file, source) {
   let match;
 
   while ((match = routerRegex.exec(source)) !== null) {
-    calls.push({
-      file,
-      type: 'router',
-      method: match.groups.method,
-      target: match.groups.arg.trim(),
-      line: lineNumberForIndex(source, match.index),
-    });
+    calls.push({ file, type: 'router', method: match.groups.method, target: match.groups.arg.trim(), line: lineNumberForIndex(source, match.index) });
   }
 
   while ((match = linkRegex.exec(source)) !== null) {
-    calls.push({
-      file,
-      type: 'Link',
-      method: 'href',
-      target: match.groups.href,
-      line: lineNumberForIndex(source, match.index),
-    });
+    calls.push({ file, type: 'Link', method: 'href', target: match.groups.href, line: lineNumberForIndex(source, match.index) });
   }
 
   return calls;
@@ -343,16 +285,26 @@ function parsePropsDeclarations(file, source) {
         .map(line => line.trim())
         .map(line => line.match(/^([A-Za-z_$][\w$]*)\??\s*:/)?.[1])
         .filter(Boolean);
-      declarations.push({
-        file,
-        name: match.groups.name,
-        fields: [...new Set(fields)],
-        line: lineNumberForIndex(source, match.index),
-      });
+      declarations.push({ file, name: match.groups.name, component: match.groups.name.replace(/Props$/, ''), fields: [...new Set(fields)], line: lineNumberForIndex(source, match.index), start: match.index, end: regex.lastIndex });
     }
   }
 
   return declarations;
+}
+
+function buildPropUsageAudit(file, source, declarations) {
+  const audits = [];
+
+  for (const declaration of declarations) {
+    const sourceWithoutDeclaration = `${source.slice(0, declaration.start)}${source.slice(declaration.end)}`;
+    const fields = declaration.fields.map(field => {
+      const references = countIdentifierUsages(sourceWithoutDeclaration, field);
+      return { name: field, references, status: references > 0 ? 'used' : 'likely-unused' };
+    });
+    audits.push({ file, name: declaration.name, component: declaration.component, line: declaration.line, fields });
+  }
+
+  return audits;
 }
 
 function parseJsxProps(file, source) {
@@ -371,12 +323,7 @@ function parseJsxProps(file, source) {
     }
 
     if (props.length > 0) {
-      usages.push({
-        file,
-        component: match.groups.component,
-        props: [...new Set(props)].sort(),
-        line: lineNumberForIndex(source, match.index),
-      });
+      usages.push({ file, component: match.groups.component, props: [...new Set(props)].sort(), line: lineNumberForIndex(source, match.index) });
     }
   }
 
@@ -390,13 +337,7 @@ function likelyUnusedImports(file, source, imports) {
   for (const importEntry of imports) {
     for (const local of importEntry.locals) {
       if (countIdentifierUsages(withoutImports, local) === 0) {
-        unused.push({
-          file,
-          local,
-          specifier: importEntry.specifier,
-          line: importEntry.line,
-          confidence: importEntry.typeOnly ? 'medium' : 'high',
-        });
+        unused.push({ file, local, specifier: importEntry.specifier, line: importEntry.line, confidence: importEntry.typeOnly ? 'medium' : 'high' });
       }
     }
   }
@@ -416,32 +357,26 @@ function groupBy(items, keyFn) {
 
 function summarizeImports(imports) {
   return Object.entries(groupBy(imports, item => item.specifier))
-    .map(([specifier, entries]) => ({
-      specifier,
-      count: entries.length,
-      files: [...new Set(entries.map(entry => entry.file))].sort(),
-    }))
+    .map(([specifier, entries]) => ({ specifier, count: entries.length, files: [...new Set(entries.map(entry => entry.file))].sort() }))
     .sort((a, b) => b.count - a.count || a.specifier.localeCompare(b.specifier));
 }
 
 function summarizeApiCalls(apiCalls) {
   return Object.entries(groupBy(apiCalls, item => `${item.client}.${item.method} ${item.route}`))
-    .map(([signature, entries]) => ({
-      signature,
-      count: entries.length,
-      files: entries.map(entry => `${entry.file}:${entry.line}`).sort(),
-    }))
+    .map(([signature, entries]) => ({ signature, count: entries.length, files: entries.map(entry => `${entry.file}:${entry.line}`).sort() }))
     .sort((a, b) => b.count - a.count || a.signature.localeCompare(b.signature));
 }
 
 function summarizeContextHooks(hooks) {
   return Object.entries(groupBy(hooks, item => item.hook))
-    .map(([hook, entries]) => ({
-      hook,
-      count: entries.length,
-      files: entries.map(entry => `${entry.file}:${entry.line}`).sort(),
-    }))
+    .map(([hook, entries]) => ({ hook, count: entries.length, files: entries.map(entry => `${entry.file}:${entry.line}`).sort() }))
     .sort((a, b) => b.count - a.count || a.hook.localeCompare(b.hook));
+}
+
+function flattenLikelyUnusedProps(propUsageAudit) {
+  return propUsageAudit.flatMap(entry => entry.fields
+    .filter(field => field.status === 'likely-unused')
+    .map(field => ({ file: entry.file, component: entry.component, propsType: entry.name, prop: field.name, line: entry.line })));
 }
 
 function noiseFiles(allFiles) {
@@ -469,72 +404,61 @@ function makeMarkdownReport(report) {
   lines.push(`- API calls: ${report.summary.apiCalls}`);
   lines.push(`- Props declarations: ${report.summary.propDeclarations}`);
   lines.push(`- JSX prop usage sites: ${report.summary.jsxPropUsages}`);
+  lines.push(`- Likely-unused props: ${report.summary.likelyUnusedProps}`);
   lines.push(`- Likely-unused imports: ${report.summary.likelyUnusedImports}`);
   lines.push(`- Generated/export/db/schema noise candidates: ${report.summary.noiseCandidates}`);
   lines.push('');
 
   lines.push('## Expo Router Screens');
   lines.push('');
-  for (const screen of report.routeScreens) {
-    lines.push(`- \`${screen.file}:${screen.line}\` ${screen.navigator}.Screen \`${screen.name}\` -> ${screen.resolved ? `\`${screen.resolved}\`` : '**missing target**'}`);
-  }
+  for (const screen of report.routeScreens) lines.push(`- \`${screen.file}:${screen.line}\` ${screen.navigator}.Screen \`${screen.name}\` -> ${screen.resolved ? `\`${screen.resolved}\`` : '**missing target**'}`);
   if (report.routeScreens.length === 0) lines.push('- No Expo Router screen declarations found.');
   lines.push('');
 
   if (missingScreens.length > 0) {
     lines.push('## Missing Route Targets');
     lines.push('');
-    for (const screen of missingScreens) {
-      lines.push(`- \`${screen.file}:${screen.line}\` declares \`${screen.name}\`; checked: ${screen.candidates.map(candidate => `\`${candidate}\``).join(', ')}`);
-    }
+    for (const screen of missingScreens) lines.push(`- \`${screen.file}:${screen.line}\` declares \`${screen.name}\`; checked: ${screen.candidates.map(candidate => `\`${candidate}\``).join(', ')}`);
     lines.push('');
   }
 
   lines.push('## Inner Tabs / TabView');
   lines.push('');
-  for (const tab of report.innerTabs) {
-    lines.push(`- \`${tab.file}:${tab.line}\` ${tab.kind}${tab.title ? ` \`${tab.title}\`` : ''}`);
-  }
+  for (const tab of report.innerTabs) lines.push(`- \`${tab.file}:${tab.line}\` ${tab.kind}${tab.title ? ` \`${tab.title}\`` : ''}`);
   if (report.innerTabs.length === 0) lines.push('- No RNEUI Tab or TabView items found.');
   lines.push('');
 
   lines.push('## Navigation Calls');
   lines.push('');
-  for (const call of report.navigationCalls) {
-    lines.push(`- \`${call.file}:${call.line}\` ${call.type}.${call.method} -> \`${call.target}\``);
-  }
+  for (const call of report.navigationCalls) lines.push(`- \`${call.file}:${call.line}\` ${call.type}.${call.method} -> \`${call.target}\``);
   if (report.navigationCalls.length === 0) lines.push('- No router/Link navigation calls found.');
   lines.push('');
 
   lines.push('## Context Hook Usage');
   lines.push('');
-  for (const hook of report.contextHookSummary) {
-    lines.push(`- \`${hook.hook}\` (${hook.count}): ${hook.files.map(file => `\`${file}\``).join(', ')}`);
-  }
+  for (const hook of report.contextHookSummary) lines.push(`- \`${hook.hook}\` (${hook.count}): ${hook.files.map(file => `\`${file}\``).join(', ')}`);
   if (report.contextHookSummary.length === 0) lines.push('- No non-core hooks found.');
   lines.push('');
 
   lines.push('## API Calls');
   lines.push('');
-  for (const api of report.apiSummary) {
-    lines.push(`- \`${api.signature}\` (${api.count}): ${api.files.map(file => `\`${file}\``).join(', ')}`);
-  }
+  for (const api of report.apiSummary) lines.push(`- \`${api.signature}\` (${api.count}): ${api.files.map(file => `\`${file}\``).join(', ')}`);
   if (report.apiSummary.length === 0) lines.push('- No direct API calls found.');
   lines.push('');
 
-  lines.push('## Props Declared by Components');
+  lines.push('## Props Declared + Usage Heuristic');
   lines.push('');
-  for (const declaration of report.propDeclarations) {
-    lines.push(`- \`${declaration.file}:${declaration.line}\` ${declaration.name}: ${declaration.fields.map(field => `\`${field}\``).join(', ') || '_no fields parsed_'}`);
+  lines.push('The prop usage check removes the Props declaration from the file, then counts references to each field in the rest of that file. Confirm with TypeScript before deleting.');
+  lines.push('');
+  for (const declaration of report.propUsageAudit) {
+    lines.push(`- \`${declaration.file}:${declaration.line}\` ${declaration.name}: ${declaration.fields.map(field => `\`${field.name}\`=${field.status}(${field.references})`).join(', ') || '_no fields parsed_'}`);
   }
-  if (report.propDeclarations.length === 0) lines.push('- No Props interfaces/types found.');
+  if (report.propUsageAudit.length === 0) lines.push('- No Props interfaces/types found.');
   lines.push('');
 
   lines.push('## JSX Prop Usage Sites');
   lines.push('');
-  for (const usage of report.jsxPropUsages) {
-    lines.push(`- \`${usage.file}:${usage.line}\` <${usage.component}>: ${usage.props.map(prop => `\`${prop}\``).join(', ')}`);
-  }
+  for (const usage of report.jsxPropUsages) lines.push(`- \`${usage.file}:${usage.line}\` <${usage.component}>: ${usage.props.map(prop => `\`${prop}\``).join(', ')}`);
   if (report.jsxPropUsages.length === 0) lines.push('- No JSX prop usage sites found.');
   lines.push('');
 
@@ -542,20 +466,14 @@ function makeMarkdownReport(report) {
   lines.push('');
   lines.push('This is a regex-based signal. Confirm with TypeScript/ESLint before deleting.');
   lines.push('');
-  for (const unused of report.likelyUnusedImports) {
-    lines.push(`- \`${unused.file}:${unused.line}\` \`${unused.local}\` from \`${unused.specifier}\` (${unused.confidence})`);
-  }
+  for (const unused of report.likelyUnusedImports) lines.push(`- \`${unused.file}:${unused.line}\` \`${unused.local}\` from \`${unused.specifier}\` (${unused.confidence})`);
   if (report.likelyUnusedImports.length === 0) lines.push('- No likely-unused imports found by this heuristic.');
   lines.push('');
 
   lines.push('## Import Summary');
   lines.push('');
-  for (const item of report.importSummary.slice(0, 80)) {
-    lines.push(`- \`${item.specifier}\` (${item.count} files)`);
-  }
-  if (report.importSummary.length > 80) {
-    lines.push(`- ...and ${report.importSummary.length - 80} more import specifiers. See JSON for full output.`);
-  }
+  for (const item of report.importSummary.slice(0, 80)) lines.push(`- \`${item.specifier}\` (${item.count} files)`);
+  if (report.importSummary.length > 80) lines.push(`- ...and ${report.importSummary.length - 80} more import specifiers. See JSON for full output.`);
   if (report.importSummary.length === 0) lines.push('- No imports found.');
   lines.push('');
 
@@ -563,9 +481,7 @@ function makeMarkdownReport(report) {
   lines.push('');
   lines.push('These are generated exports, dumps, or schema/db artifacts that should not drive navigation logic. Review before deletion.');
   lines.push('');
-  for (const file of report.noiseCandidates) {
-    lines.push(`- \`${file}\``);
-  }
+  for (const file of report.noiseCandidates) lines.push(`- \`${file}\``);
   if (report.noiseCandidates.length === 0) lines.push('- No obvious generated export/db/schema noise candidates found.');
   lines.push('');
 
@@ -585,6 +501,7 @@ async function main() {
   const innerTabs = [];
   const navigationCalls = [];
   const propDeclarations = [];
+  const propUsageAudit = [];
   const jsxPropUsages = [];
   const likelyUnused = [];
 
@@ -593,6 +510,7 @@ async function main() {
     const absolute = path.join(frontendRoot, file);
     const source = await fs.readFile(absolute, 'utf8');
     const fileImports = parseImports(file, source);
+    const filePropDeclarations = parsePropsDeclarations(file, source);
 
     imports.push(...fileImports);
     apiCalls.push(...parseApiCalls(file, source));
@@ -600,11 +518,13 @@ async function main() {
     routeScreens.push(...parseExpoRouterScreens(file, source, allSourceFileSet));
     innerTabs.push(...parseInnerTabs(file, source));
     navigationCalls.push(...parseNavigationCalls(file, source));
-    propDeclarations.push(...parsePropsDeclarations(file, source));
+    propDeclarations.push(...filePropDeclarations);
+    propUsageAudit.push(...buildPropUsageAudit(file, source, filePropDeclarations));
     jsxPropUsages.push(...parseJsxProps(file, source));
     likelyUnused.push(...likelyUnusedImports(file, source, fileImports));
   }
 
+  const likelyUnusedProps = flattenLikelyUnusedProps(propUsageAudit);
   const report = {
     generatedAt: new Date().toISOString(),
     frontendRoot: normalizePath(frontendRoot),
@@ -618,6 +538,7 @@ async function main() {
       apiCalls: apiCalls.length,
       propDeclarations: propDeclarations.length,
       jsxPropUsages: jsxPropUsages.length,
+      likelyUnusedProps: likelyUnusedProps.length,
       likelyUnusedImports: likelyUnused.length,
       noiseCandidates: noiseFiles(allFiles).length,
     },
@@ -629,6 +550,8 @@ async function main() {
     apiSummary: summarizeApiCalls(apiCalls),
     apiCalls,
     propDeclarations,
+    propUsageAudit,
+    likelyUnusedProps,
     jsxPropUsages,
     likelyUnusedImports: likelyUnused.sort((a, b) => a.file.localeCompare(b.file) || a.line - b.line),
     importSummary: summarizeImports(imports),


### PR DESCRIPTION
## Summary

- Adds `frontend/scripts/audit-navigation-usage.mjs` to dynamically audit Expo Router screens, dashboard tabs, navigation calls, context hook usage, API calls, props usage, unused-import signals, and generated/db/schema noise candidates as the component tree grows.
- Adds `npm run audit:navigation` in `frontend/package.json`.
- Adds `frontend/audits/navigation-usage-audit.md` with the current findings and a consolidation plan.

## Key findings documented

- Current root app provider tree does not match the richer provider tree used in tests.
- `(auth)` stack and legacy `(app)` tabs appear to be competing navigation shells.
- `fidget/index` is declared in the authenticated stack, but the matching route file was not found in review.
- No live side drawer route implementation was found; docs/code should either add a drawer from a route registry or remove drawer references until it exists.
- Task logic is split across TaskContext, direct axios/API calls, Redux, and service classes.
- API calls mix localhost URLs, `/tasks`, and `/api/...` route conventions.
- Generated export files are flagged as noise candidates before deletion.

## Validation

- Ran `node --check` locally on the audit script syntax before committing.
- GitHub connector changes are limited to docs/package script/new audit script; no runtime app code changed.
